### PR TITLE
Use native `httptest` package for tests

### DIFF
--- a/.github/workflows/worker-tests.yaml
+++ b/.github/workflows/worker-tests.yaml
@@ -20,10 +20,6 @@ jobs:
         run: |
           docker compose build
 
-      - name: Start worker in background
-        run: |
-          docker compose up -d
-
       - name: Run tests
         run: |
           go test ./tests/worker/...

--- a/tests/worker/list_tasks_test.go
+++ b/tests/worker/list_tasks_test.go
@@ -2,21 +2,26 @@ package worker
 
 import (
 	"dirigeant/task"
+	"dirigeant/worker"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListTasks__ShouldReturnAnEmptyList(t *testing.T) {
-	resp, err := http.Get("http://localhost:8080/tasks")
-	if err != nil {
-		t.Error(err)
+func TestListTasks__ShouldReturnAnEmptySlice(t *testing.T) {
+	request := httptest.NewRequest("GET", "/tasks", nil)
+	responseRecorder := httptest.NewRecorder()
+
+	api := &worker.Api{
+		Worker: &worker.Worker{},
 	}
+	api.HandleListTasks(responseRecorder, request)
 
 	tasks := []task.Task{}
-	json.NewDecoder(resp.Body).Decode(&tasks)
-
-	assert.Equal(t, tasks, []task.Task{}, "Returned tasks list should an empty slice")
+	json.NewDecoder(responseRecorder.Body).Decode(&tasks)
+	assert.Equal(t, responseRecorder.Code, http.StatusOK, "Response status code should be 200")
+	assert.Equal(t, tasks, []task.Task{}, "Response body should be an empty slice")
 }


### PR DESCRIPTION
Because it allows us to use ephemeral server in each test. I intentionally left building the Docker image to be able to use it in other tests that may rely on https://golang.testcontainers.org/